### PR TITLE
Delete friends

### DIFF
--- a/src/lib/components/auth/invitation/FriendsInvitationList.svelte
+++ b/src/lib/components/auth/invitation/FriendsInvitationList.svelte
@@ -20,7 +20,7 @@ The component get invitation from the server
  -->
 <ul class="column gap-12 {friends ? 'gap-4' : ''}">
 	{#each dataArray as data}
-		<User {friends} {data} {button} {shadow} {sizeImg} />
+		<User canDelete {friends} {data} {button} {shadow} {sizeImg} />
 	{:else}
 		<h4>{nothingMessage}</h4>
 	{/each}

--- a/src/lib/components/auth/invitation/User.svelte
+++ b/src/lib/components/auth/invitation/User.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import DeleteButton from '$lib/components/extra/multiButton/DeleteButton.svelte';
+	import MultiButton from '$lib/components/extra/multiButton/MultiButton.svelte';
+	import { confirmDelete } from '$lib/functions/modal/confirmDelete';
 	import type { GetUser } from '$lib/models/user.model';
+	import { getModalStore, type ModalStore } from '@skeletonlabs/skeleton';
 
 	export let shadow =
 		'shadow-[31px_31px_82px_0_rgba(190,190,190,1),-31px_-31px_82px_0_rgba(255,255,255,1)]';
@@ -10,6 +14,9 @@
 	export let data: GetUser & { idDriver?: string };
 	export let addButton = false;
 	export let friends = false;
+	export let canDelete = false;
+
+	const modalStore: ModalStore = getModalStore();
 </script>
 
 <li
@@ -114,6 +121,29 @@
 					</div>
 				</div>
 			</form>
+		{:else if canDelete}
+			<MultiButton index={0} identification="gift" side="end">
+				<form
+					slot="summary"
+					on:submit={async (event) => {
+						const res = await confirmDelete(
+							event,
+							modalStore,
+							`Êtes vous sur de vouloir supprimer ${data.user.email} ?`
+						);
+
+						if (res.success) {
+							location.reload();
+						}
+					}}
+					method="POST"
+					action="?/deleteFriend"
+					class="p-2"
+				>
+					<input name="id" type="hidden" value={data.user.id} />
+					<DeleteButton customtext="Supprimer" />
+				</form>
+			</MultiButton>
 		{/if}
 	</div>
 </li>

--- a/src/lib/server/friends.server.ts
+++ b/src/lib/server/friends.server.ts
@@ -29,4 +29,30 @@ export default class FriendsApi extends Api {
 			throw error;
 		}
 	}
+
+	/**
+	 * Deletes a friend by their unique identifier.
+	 *
+	 * Sends a DELETE request to the server to remove the friend with the specified ID.
+	 * Handles errors by logging them and rethrowing for upstream handling.
+	 *
+	 * @param id - The unique identifier of the friend to delete.
+	 * @returns A promise that resolves to an {@link ApiResponse} containing the server's response.
+	 * @throws Will rethrow any errors encountered during the request.
+	 */
+	async deleteFriend(id: string): Promise<ApiResponse> {
+		try {
+			const response = await this.fetch(`${this.authUrl}delete/${id}`, {
+				method: 'DELETE',
+
+				credentials: 'include'
+			});
+
+
+			return await response.json();
+		} catch (error) {
+			catchErrorRequest(error, 'FriendsApi.deleteFriends');
+			throw error;
+		}
+	}
 }

--- a/src/routes/auth/friends/+page.server.ts
+++ b/src/routes/auth/friends/+page.server.ts
@@ -97,5 +97,30 @@ export const actions: Actions = {
 		}
 
 		return JSON.stringify({ success: true });
+	},
+
+	deleteFriend: async (event) => {
+
+		const form = await superValidate(event, zod(uuidSchema));
+
+		if (!form.valid) {
+			return JSON.stringify({
+				error: 'Formulaire invalide, veuillez vérifier les champs.'
+			});
+		}
+
+		const api = new FriendsApi(event.fetch);
+		const res = await api.deleteFriend(form.data.id);
+
+		if ('error' in res) {
+			return JSON.stringify({
+				error: res.error ? res.error.error : 'Unknown error occurred'
+			});
+		}
+
+		return JSON.stringify({
+			status: 200,
+			success: true
+		});
 	}
 };

--- a/src/routes/auth/friends/+page.svelte
+++ b/src/routes/auth/friends/+page.svelte
@@ -95,7 +95,6 @@
 
 	<section class="wrap px-4 flex flex-col gap-8">
 		<FriendsInvitationList
-			friends
 			shadow="shadow-[15px_15px_60px_0_rgba(190,190,190,1),-15px_-15px_60px_0_rgba(255,255,255,1)]"
 			sizeImg="size-12"
 			dataArray={paginatedSource}


### PR DESCRIPTION
Copier
Cette pull request introduit une fonctionnalité pour supprimer des amis de la liste d'invitation, incluant des mises à jour de l'UI, une intégration API côté serveur et une validation de formulaire. Les changements clés sont regroupés en améliorations de l'UI, fonctionnalités côté serveur et logique d'intégration.

### Améliorations de l'UI :
* Mise à jour de `FriendsInvitationList.svelte` pour passer une nouvelle prop `canDelete` au composant `User`, activant la fonctionnalité de suppression dans l'UI.
* Modification de `User.svelte` pour inclure un bouton de suppression dans un composant `MultiButton`, qui déclenche une modale de confirmation et envoie une requête de suppression après confirmation de l'utilisateur. Ajout de la prop `canDelete` et intégration de la gestion de la modale avec `getModalStore`. [[1]](diffhunk://#diff-ae825eb64f91be2113a4b34944887b48cec135b219f9521f5f000e9ae73accfeR3-R7) [[2]](diffhunk://#diff-ae825eb64f91be2113a4b34944887b48cec135b219f9521f5f000e9ae73accfeR17-R19) [[3]](diffhunk://#diff-ae825eb64f91be2113a4b34944887b48cec135b219f9521f5f000e9ae73accfeR124-R146)

### Fonctionnalités côté serveur :
* Ajout d'une méthode `deleteFriend` dans `FriendsApi` pour envoyer des requêtes DELETE au serveur pour supprimer des amis par leur ID unique. Inclut la gestion des erreurs et l'analyse des réponses.
* Mise à jour de `+page.server.ts` pour inclure une nouvelle action `deleteFriend` qui valide la requête en utilisant `superValidate`, appelle la méthode `FriendsApi.deleteFriend` et gère les réponses d'erreur ou de succès.

### Logique d'intégration :
* Ajustement de `+page.svelte` pour supprimer la prop `friends` du composant `FriendsInvitationList`, simplifiant son utilisation.